### PR TITLE
Cleaned up play command and fixed loopBug

### DIFF
--- a/GroovierCSharp/CommandModules/JoinLeaveCommandModules.cs
+++ b/GroovierCSharp/CommandModules/JoinLeaveCommandModules.cs
@@ -39,7 +39,20 @@ public class JoinLeaveCommandModules : ApplicationCommandModule
     [SlashCommand("Leave", "Leaves the voice channel")]
     public static async Task Leave(InteractionContext ctx)
     {
-        await ControllerCommandModules.ConnectionSetup(ctx);
+        var vnext = ctx.Client.GetLavalink();
+        if (vnext is null)
+        {
+            await ctx.CreateResponseAsync("Lavalink is not connected.");
+            return;
+        }
+
+        var node = vnext.ConnectedNodes.Values.First();
+        if (node is null)
+        {
+            await ctx.CreateResponseAsync("No connection nodes found.");
+            return;
+        }
+
         ControllerCommandModules.Queue.Clear();
         await ControllerCommandModules.Connection.DisconnectAsync();
         var embed = ControllerCommandModules.EmbedCreator("Join",

--- a/GroovierCSharp/Setup.cs
+++ b/GroovierCSharp/Setup.cs
@@ -45,10 +45,10 @@ public class Setup
         var client = new DiscordClient(config);
         var lavalink = client.UseLavalink();
         var commands = client.UseSlashCommands();
-        commands.RegisterCommands<ControllerCommandModules>(880830252740390992);
-        commands.RegisterCommands<JoinLeaveCommandModules>(880830252740390992);
-        commands.RegisterCommands<QueueControlCommandModules>(880830252740390992);
-        commands.RegisterCommands<PlaybackControlCommandModules>(880830252740390992);
+        commands.RegisterCommands<ControllerCommandModules>();
+        commands.RegisterCommands<JoinLeaveCommandModules>();
+        commands.RegisterCommands<QueueControlCommandModules>();
+        commands.RegisterCommands<PlaybackControlCommandModules>();
         await client.ConnectAsync();
         await lavalink.ConnectAsync(lavalinkConfig);
     }

--- a/GroovierCSharp/Setup.cs
+++ b/GroovierCSharp/Setup.cs
@@ -45,10 +45,10 @@ public class Setup
         var client = new DiscordClient(config);
         var lavalink = client.UseLavalink();
         var commands = client.UseSlashCommands();
-        commands.RegisterCommands<ControllerCommandModules>();
-        commands.RegisterCommands<JoinLeaveCommandModules>();
-        commands.RegisterCommands<QueueControlCommandModules>();
-        commands.RegisterCommands<PlaybackControlCommandModules>();
+        commands.RegisterCommands<ControllerCommandModules>(880830252740390992);
+        commands.RegisterCommands<JoinLeaveCommandModules>(880830252740390992);
+        commands.RegisterCommands<QueueControlCommandModules>(880830252740390992);
+        commands.RegisterCommands<PlaybackControlCommandModules>(880830252740390992);
         await client.ConnectAsync();
         await lavalink.ConnectAsync(lavalinkConfig);
     }


### PR DESCRIPTION
This pull request includes several changes to the `ControllerCommandModules`, `JoinLeaveCommandModules`, and `Setup` classes to improve the handling of Lavalink connections and enhance error handling. The most important changes include the refactoring of the `Play` method, addition of helper methods, and updates to command registration.

Improvements to `ControllerCommandModules`:

* Refactored the `Play` method to simplify the node connection check and handle both URI and query strings for track loading. Added error handling for track loading failures. [[1]](diffhunk://#diff-07f635ed370a2c8c904e91cbc98dd689891768e9a7528475011096d96f403511L22-R23) [[2]](diffhunk://#diff-07f635ed370a2c8c904e91cbc98dd689891768e9a7528475011096d96f403511L37-R61)
* Added `LoadFeedback` and `PlaySong` helper methods to handle feedback and song playback separately, improving code readability and maintainability. [[1]](diffhunk://#diff-07f635ed370a2c8c904e91cbc98dd689891768e9a7528475011096d96f403511L37-R61) [[2]](diffhunk://#diff-07f635ed370a2c8c904e91cbc98dd689891768e9a7528475011096d96f403511R70-R81)
* Removed redundant initialization of the `Loop` property.

Enhancements to `JoinLeaveCommandModules`:

* Improved the `Leave` method to include checks for Lavalink connection and node availability, providing more informative responses to the user.

Updates to `Setup`:

* Updated command registration to include a specific guild ID, ensuring commands are registered only within the specified guild.