### PR TITLE
Fixed #18

### DIFF
--- a/GroovierCSharp/CommandModules/ControllerCommandModules.cs
+++ b/GroovierCSharp/CommandModules/ControllerCommandModules.cs
@@ -96,6 +96,7 @@ public class ControllerCommandModules : ApplicationCommandModule
 
     private static async Task OnPlaybackFinished(LavalinkGuildConnection sender, TrackFinishEventArgs e)
     {
+        if (Connection.CurrentState.CurrentTrack is not null) return;
         if (Loop)
         {
             History.Enqueue(History.Last());


### PR DESCRIPTION
This pull request includes a small change to the `GroovierCSharp/CommandModules/ControllerCommandModules.cs` file. The change adds a check to the `PlaySong` method to ensure that the current track is not null before proceeding with the playback finished logic.

Change to playback logic:

* [`GroovierCSharp/CommandModules/ControllerCommandModules.cs`](diffhunk://#diff-07f635ed370a2c8c904e91cbc98dd689891768e9a7528475011096d96f403511R99): Added a check in the `PlaySong` method to return early if the `CurrentTrack` is not null.…he queue