### PR TITLE
Fixed bug where remove command would not work

### DIFF
--- a/GroovierCSharp/CommandModules/QueueControlCommandModules.cs
+++ b/GroovierCSharp/CommandModules/QueueControlCommandModules.cs
@@ -70,6 +70,7 @@ public class QueueControlCommandModules : ApplicationCommandModule
         ControllerCommandModules.Queue = new ConcurrentQueue<LavalinkTrack>(queue);
         var removeEmbed = ControllerCommandModules.EmbedCreator("Queue", $"Removed {track.Title} from the queue.");
         await ctx.CreateResponseAsync(removeEmbed);
+        GC.Collect();
     }
 
     [SlashCommand("NowPlaying", "Shows the currently playing song")]

--- a/GroovierCSharp/CommandModules/QueueControlCommandModules.cs
+++ b/GroovierCSharp/CommandModules/QueueControlCommandModules.cs
@@ -56,17 +56,18 @@ public class QueueControlCommandModules : ApplicationCommandModule
         [Option("index", "The index of the song to remove")]
         long index)
     {
-        index++;
-        if (index < 1 || index >= ControllerCommandModules.Queue.Count)
+        index -= 1;
+        if (index < 0 || index >= ControllerCommandModules.Queue.Count)
         {
             var embed = ControllerCommandModules.EmbedCreator("Queue", "Invalid index.");
             await ctx.CreateResponseAsync(embed);
             return;
         }
 
-        var track = ControllerCommandModules.Queue.ElementAt((int)index);
-        ControllerCommandModules.Queue =
-            new ConcurrentQueue<LavalinkTrack>(ControllerCommandModules.Queue.Where(t => t != track));
+        var queue = ControllerCommandModules.Queue.ToList();
+        var track = queue[(int)index];
+        queue.RemoveAt((int)index);
+        ControllerCommandModules.Queue = new ConcurrentQueue<LavalinkTrack>(queue);
         var removeEmbed = ControllerCommandModules.EmbedCreator("Queue", $"Removed {track.Title} from the queue.");
         await ctx.CreateResponseAsync(removeEmbed);
     }


### PR DESCRIPTION
This pull request includes a change to the `Remove` method in the `QueueControlCommandModules` class to fix an off-by-one error and improve the queue manipulation logic.

Changes to `Remove` method:

* Modified the index adjustment to decrement instead of increment, ensuring the correct range check for the index.
* Changed the queue manipulation logic to convert the queue to a list, remove the track by index, and then convert it back to a `ConcurrentQueue`. This simplifies the removal process and avoids the need for filtering the queue.