### PR TITLE
Made it so the bot has a status of listening to /play and is on DND

### DIFF
--- a/GroovierCSharp/Setup.cs
+++ b/GroovierCSharp/Setup.cs
@@ -1,4 +1,5 @@
 using DSharpPlus;
+using DSharpPlus.Entities;
 using DSharpPlus.Lavalink;
 using DSharpPlus.Net;
 using DSharpPlus.SlashCommands;
@@ -28,6 +29,11 @@ public class Setup
             Intents = DiscordIntents.AllUnprivileged | DiscordIntents.GuildVoiceStates | DiscordIntents.GuildMessages |
                       DiscordIntents.Guilds
         };
+        var activity = new DiscordActivity
+        {
+            Name = "/Play",
+            ActivityType = ActivityType.ListeningTo
+        };
 
         var endpoint = new ConnectionEndpoint
         {
@@ -49,7 +55,7 @@ public class Setup
         commands.RegisterCommands<JoinLeaveCommandModules>();
         commands.RegisterCommands<QueueControlCommandModules>();
         commands.RegisterCommands<PlaybackControlCommandModules>();
-        await client.ConnectAsync();
+        await client.ConnectAsync(activity, UserStatus.DoNotDisturb);
         await lavalink.ConnectAsync(lavalinkConfig);
     }
 


### PR DESCRIPTION
This pull request includes changes to the `GroovierCSharp/Setup.cs` file to enhance the bot's activity status and improve its connection setup. The most important changes include importing a new namespace and modifying the `Run` method to set a custom activity and user status when connecting the client.

Enhancements to bot activity and connection setup:

* [`GroovierCSharp/Setup.cs`](diffhunk://#diff-a1b64e8783bb9c43f183411e0b307ad0cef37f72ded11ec98884b8426f40d1f9R2): Added `using DSharpPlus.Entities;` to import necessary types for setting Discord activity.
* [`public static async Task Run()`](diffhunk://#diff-a1b64e8783bb9c43f183411e0b307ad0cef37f72ded11ec98884b8426f40d1f9R32-R36): Introduced a `DiscordActivity` object with the name "/Play" and activity type `ListeningTo`, and modified the `ConnectAsync` call to include this activity and set the user status to `DoNotDisturb`. [[1]](diffhunk://#diff-a1b64e8783bb9c43f183411e0b307ad0cef37f72ded11ec98884b8426f40d1f9R32-R36) [[2]](diffhunk://#diff-a1b64e8783bb9c43f183411e0b307ad0cef37f72ded11ec98884b8426f40d1f9L52-R58)