### PR TITLE
Made it so the bot disconnects after 15mins

### DIFF
--- a/GroovierCSharp/CommandModules/ControllerCommandModules.cs
+++ b/GroovierCSharp/CommandModules/ControllerCommandModules.cs
@@ -134,6 +134,7 @@ public class ControllerCommandModules : ApplicationCommandModule
         Queue.Clear();
         _disconnectTimer?.Dispose();
         _disconnectTimer = null;
+        GC.Collect();
     }
 
     [SlashCommand("Pause", "Pauses the current song")]


### PR DESCRIPTION
This pull request introduces a new feature to manage the bot's disconnection from the voice channel when there are no more songs in the queue. The changes include adding a timer to automatically disconnect the bot after a period of inactivity and resetting the timer when a new song starts playing.

Key changes:

* Added a `_disconnectTimer` field to the `ControllerCommandModules` class to manage the disconnection timer. (`GroovierCSharp/CommandModules/ControllerCommandModules.cs`)
* Modified the `PlaySong` method to reset the disconnection timer when a new song starts playing. (`GroovierCSharp/CommandModules/ControllerCommandModules.cs`)
* Added the `StartDisconnectTimer`, `ResetDisconnectTimer`, and `DisconnectBot` methods to handle the timer logic and disconnect the bot when the timer elapses. (`GroovierCSharp/CommandModules/ControllerCommandModules.cs`)